### PR TITLE
Update gemma-finetuning.ipynb

### DIFF
--- a/workspace/gemma-finetuning.ipynb
+++ b/workspace/gemma-finetuning.ipynb
@@ -582,7 +582,7 @@
    "source": [
     "# Adapter load path\n",
     "base = AutoModelForCausalLM.from_pretrained(\n",
-    "    \"output-full\", dtype=\"auto\", device_map=\"auto\", attn_implementation=\"flash_attention_2\"\n",
+    "    f\"output-{model_name}-full\", dtype=\"auto\", device_map=\"auto\", attn_implementation=\"flash_attention_2\"\n",
     ")\n",
     "tok = AutoTokenizer.from_pretrained(MODEL)\n",
     "\n",
@@ -630,7 +630,7 @@
     "    MODEL, dtype=\"auto\", device_map=\"auto\", attn_implementation=\"flash_attention_2\"\n",
     ")\n",
     "tok = AutoTokenizer.from_pretrained(MODEL)\n",
-    "peft_model = PeftModel.from_pretrained(base, \"output-lora\")\n",
+    "peft_model = PeftModel.from_pretrained(base, f\"output-{model_name}-lora\")\n",
     "\n",
     "from transformers import pipeline\n",
     "pipe = pipeline(\"text-generation\", model=base, tokenizer=tok)\n",


### PR DESCRIPTION
Fix hardcoded output paths in inference sections to use model_name variable.

Changes:
- Full fine-tuning inference: "output-full" → f"output-{model_name}-full"
- LoRA inference: "output-lora" → f"output-{model_name}-lora"

This allows the notebook to work correctly when users change the MODEL variable to test different Gemma variants.