### PR TITLE
fix(train): call save_model() on all ranks for FSDP compatibility

### DIFF
--- a/workspace/train.py
+++ b/workspace/train.py
@@ -420,7 +420,7 @@ def main():
         print(f"Time:   {elapsed:.2f}s")
         print(f"Peak:   {peak:.2f} GB")
         print("-" * 50)
-        trainer.save_model()
+    trainer.save_model()
 
     full_cleanup(model, trainer)
 


### PR DESCRIPTION
## Summary

`trainer.save_model()` is currently wrapped in `if is_main:` in `workspace/train.py`. That's correct for DDP (each rank holds a full model replica, rank 0 can save alone) but breaks FSDP: with sharded parameters, `save_model()` triggers a state_dict all-gather — a collective that requires participation from every rank.

## Symptom

On a 2-node FSDP run the non-main rank exits cleanly after the training loop, then the main rank aborts in `_all_gather_flat_param` when it tries to collect shards from the peer that's already gone:

```
socketProgress: Connection closed by remote peer
SIGABRT on rank 0
```

DDP was permissive enough to hide this.

## Fix

Move `trainer.save_model()` outside the `if is_main:` block so both strategies share one save path. HF Trainer already writes only on rank 0 internally, so this does not produce duplicate files.

## Test plan

- [x] Reproduced the FSDP crash on 2× GMKtec EVO-X2 (Strix Halo, gfx1151), torch `2.12.0a0+rocm7.12` + ROCm 7 nightly, USB4 interconnect
- [x] Verified 2-node FSDP run now completes end-to-end and writes `adapter_model.safetensors` + `adapter_config.json` (SmolLM2-135M-Instruct, LoRA, `--strategy fsdp`)
- [x] Verified 2-node DDP behavior unchanged (same model, `--strategy ddp`)
- [x] Confirmed only one set of adapter files is written (HF Trainer handles rank-0 gating internally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)